### PR TITLE
work cleanly with read-stream and readable-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "devDependencies": {
     "test": "~0.6.0",
     "repl-utils": "~2.0.1",
-    "reducers": "~2.0.0"
+    "reducers": "~2.0.0",
+    "read-stream": "~0.5.2"
   },
   "main": "./stream.js",
   "scripts": {
@@ -41,6 +42,7 @@
     }
   ],
   "dependencies": {
-    "reducible": "~1.0.1"
+    "reducible": "~1.0.1",
+    "write-stream": "~0.4.3"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -2,4 +2,6 @@
 
 exports["test reduce read stream"] = require("./read-stream")
 
+exports["test reduce readable"] = require("./readable")
+
 require("test").run(exports)

--- a/test/readable.js
+++ b/test/readable.js
@@ -1,0 +1,23 @@
+var fromArray = require("read-stream/array")
+
+var fold = require("reducers/fold")
+
+require("../stream")
+
+exports["test folding a stream"] = function (assert, done) {
+  var stream = fromArray([1, 2, 3])
+  var result = []
+
+  var r = fold(stream, function (data, acc) {
+    result.push(data)
+    return acc
+  }, {})
+
+  fold(r, function () {
+    assert.deepEqual(result, [1, 2, 3], "can reduce read-stream")
+    done()
+  })
+}
+
+if (require.main === module)
+  require("test").run(exports)


### PR DESCRIPTION
Uses `pipe` instead of `on("data"`

This also allows multiple parallel folds on the same stream and doesn't bump streams2 into old mode.

The `if (stream.readable)` check has to go as streams2 doesn't have that boolean.
